### PR TITLE
Add force_error filter key

### DIFF
--- a/lib/ruby_reportable/report.rb
+++ b/lib/ruby_reportable/report.rb
@@ -311,7 +311,7 @@ module RubyReportable
           end
         elsif !filter_validity.nil? && !filter_validity[:status].nil? && filter_validity[:status] == false
           # Ignore an empty filter unless it's required
-          if !sandbox[:input].to_s.blank?
+          if !sandbox[:input].to_s.blank? || filter_validity[:force_requre] == true
             errors << filter_validity[:errors]
             false
           else

--- a/lib/ruby_reportable/report.rb
+++ b/lib/ruby_reportable/report.rb
@@ -311,7 +311,7 @@ module RubyReportable
           end
         elsif !filter_validity.nil? && !filter_validity[:status].nil? && filter_validity[:status] == false
           # Ignore an empty filter unless it's required
-          if !sandbox[:input].to_s.blank? || filter_validity[:force_requre] == true
+          if !sandbox[:input].to_s.blank? || filter_validity[:force_require] == true
             errors << filter_validity[:errors]
             false
           else

--- a/lib/ruby_reportable/report.rb
+++ b/lib/ruby_reportable/report.rb
@@ -310,8 +310,8 @@ module RubyReportable
             true
           end
         elsif !filter_validity.nil? && !filter_validity[:status].nil? && filter_validity[:status] == false
-          # Ignore an empty filter unless it's required
-          if !sandbox[:input].to_s.blank? || filter_validity[:force_require] == true
+          # Ignore an empty filter unless it's required or the error is forced.
+          if !sandbox[:input].to_s.blank? || filter_validity[:force_error] == true
             errors << filter_validity[:errors]
             false
           else


### PR DESCRIPTION
This new key will force the filter to be invalid, no matter what.  This fixes a problem where, if a filter is required because another filter is empty, yet it doesn't have the "require" keyword, ruby-reportable was ignoring that the status key was being set to false and was ignoring that the filter was invalid.
